### PR TITLE
Fix broken completion help for xwwp-follow-link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ please open an issue or better, create a pull request!
 
 - Damien Merenne <dam@cosinux.org>
 - Q. Hong <qhong@mit.edu>
+- Masahiro Nakamura <tsuucat@icloud.com>

--- a/xwwp-follow-link.el
+++ b/xwwp-follow-link.el
@@ -154,10 +154,10 @@ ACTION should be called with the resulting link.
 UPDATE-FN is a function that can be called when the candidates
 list is narrowed.It will highlight the link list in the
 browser."
-  (funcall action (cdr (assoc (completing-read prompt (lambda (str pred _)
+  (funcall action (cdr (assoc (completing-read prompt (lambda (str pred flag)
                                                         (oset backend text str)
                                                         (funcall update-fn)
-                                                        (try-completion str collection pred))
+                                                        (complete-with-action flag collection str pred))
                                                nil t)
                               collection))))
 


### PR DESCRIPTION
Hi,
I found \*Completions\* buffer by `minibuffer-completion-help` is not shown when `xwwp-follow-link-completion-system` is `default`.
(IOW typing `?` or twice `TAB` in minibuffer for `xwwp-follow-link` doesn't work.)

I fixed the bug.